### PR TITLE
small numerical fixes to lecture 24, 25, and 26

### DIFF
--- a/lecture_24/main.tex
+++ b/lecture_24/main.tex
@@ -226,7 +226,7 @@ so $M = 1$, as $1$ is clearly the only nonnegative real $N$th of unity. Thus,
 \[
     e^{jN\theta} = 1.
 \]
-One solution to this is clearly $\theta = 1$, which gives rise to the trivial root $Z = 1$. However, we claim that $\theta = 2\pi m / N$ is also a solution, where $m$ is any integer. We can see this by substituting
+One solution to this is clearly $\theta = 0$, which gives rise to the trivial root $Z = 1$. However, we claim that $\theta = 2\pi m / N$ is also a solution, where $m$ is any integer. We can see this by substituting
 \eqn{
     && Z^N &= (e^{j\theta})^N \\
     &&&= e^{j(2\pi m / N) N} \\

--- a/lecture_25/main.tex
+++ b/lecture_25/main.tex
@@ -282,7 +282,7 @@ Now, observe that since $a \ne b$, our summation is actually just the summation 
     && \langle \vec{u}_a^T, \vec{u}_b^T \rangle &= \sum_{k=0}^{N-1} (\omega_N^{b-a})^k \\
     &&&= \frac{1 - (\omega_N^{b-a})^N}{1 - \omega_N^{b-a}}.
 }
-Observe that for $a \ne b$, the denominator is nonzero, so this expression is defined. However, observe that since $\omega_N^{b-a}$ is an $N$th root of unity raised to an integer power, it is itself a root of unity. By definition, therefore, $(\omega_N^{b-a})^N = 1$\footnote{If you're not comfortable with the properties of roots of unity, you can of course show this directly by swapping the order of the powers. But going about it this way helps build intuition for complex numbers and is marginally simpler.}. Substituting into the above expression, we obtain
+Observe that for $a \ne b$, the denominator is nonzero, so this expression is defined. However, observe that since $\omega_N^{b-a}$ is an $N$th root of unity raised to an integer power, it is itself a root of unity. By definition, therefore, $(\omega_N^{b-a})^N = 1$.\footnote{If you're not comfortable with the properties of roots of unity, you can of course show this directly by swapping the order of the powers. But going about it this way helps build intuition for complex numbers and is marginally simpler.} Substituting into the above expression, we obtain
 \eqn{
     && \langle \vec{u}_a^T, \vec{u}_b^T \rangle &= \frac{1 - (\omega_N^{b-a})^N}{1 - \omega_N^{b-a}} \\
     &&&= \frac{0}{1 - \omega_N^{b-a}} \\

--- a/lecture_25/main.tex
+++ b/lecture_25/main.tex
@@ -208,7 +208,7 @@ To simplify this matrix representation, recall that $\omega_3$, being a cube roo
     && \omega^{-2} &= \omega^{-2} \cdot \omega^3 = \omega^1 = \omega \\
     && \omega^{-4} &= \omega^{-4} \cdot \omega^3 \cdot \omega^3 = \omega^2.
 }
-Notice further that clearly $\omega_3^0 = 0$. Thus, we can simplify our representation of $F_3$ to become
+Notice further that clearly $\omega_3^0 = 1$. Thus, we can simplify our representation of $F_3$ to become
 \[
     F_3 = \mat{
     1 & 1 & 1 \\

--- a/lecture_26/main.tex
+++ b/lecture_26/main.tex
@@ -258,7 +258,7 @@ pulling the root of unity $\omega_N$ out from the exponential terms. For notatio
 
 Recall that we defined the $\vec{u}_l$ to be the columns (or rows, since $F_N$ is symmetric) of $F_N$. Observe in particular that we can rewrite the above expression as
 \eqn{
-    && \vec{x}[k] &= \frac{1}{2} (C_l\omega_N^{lk} + \overline{C_l}\omega_N^{-ll}) \\
+    && \vec{x}[k] &= \frac{1}{2} (C_l\omega_N^{lk} + \overline{C_l}\omega_N^{-lk}) \\
     &&&= \frac{1}{2} (C_l\omega_N^{(l - lN)k} + \overline{C_l}\omega_N^{-lk}) \\
     &&&= \frac{1}{2} (C_l\omega_N^{-(N - 1)lk} + \overline{C_l}\omega_N^{-lk}),
 }


### PR DESCRIPTION
### Lecture 24

- Updated "theta = 1" to "theta = 0" as the trivial way to set the equation equal to 0

### Lecture 25

- updated w^0 = 0 to w^0 = 1
- moved period before the second footnote so that it's clear that there is a footnote and it's not "1^2"

### Lecture 26

- updated "ll" to "lk" in the exponent 

Not 100% confident on my math, but I these were some typos I came across! 

(also, kudos I used to be pretty confused on how roots of unity worked from 170, but this explanation was super clear!!)